### PR TITLE
examples: Add PlatformIO ini files.

### DIFF
--- a/examples/decode_file/.gitignore
+++ b/examples/decode_file/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/examples/decode_file/platformio.ini
+++ b/examples/decode_file/platformio.ini
@@ -1,0 +1,26 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = esp32dev
+
+src_dir = main
+include_dir = ../../speex/include
+lib_dir = ../../speex/libspeex
+
+[base]
+platform = espressif32
+framework = espidf
+
+monitor_speed = 115200
+
+[env:esp32dev]
+extends = base
+board = esp32dev

--- a/examples/encode_file/.gitignore
+++ b/examples/encode_file/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/examples/encode_file/platformio.ini
+++ b/examples/encode_file/platformio.ini
@@ -1,0 +1,26 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = esp32dev
+
+src_dir = main
+include_dir = ../../speex/include
+lib_dir = ../../speex/libspeex
+
+[base]
+platform = espressif32
+framework = espidf
+
+monitor_speed = 115200
+
+[env:esp32dev]
+extends = base
+board = esp32dev


### PR DESCRIPTION
Install PlatformIO extension in VScode.
Open folder with platformio.ini (examples/encode_file or examples/decode_file) in VScode. Build, Upload and Monitor example in VScode.